### PR TITLE
Improve student stats page UI

### DIFF
--- a/QuizClient/QuizClient/StudentStats.xaml
+++ b/QuizClient/QuizClient/StudentStats.xaml
@@ -1,19 +1,70 @@
-﻿<Page x:Class="QuizClient.StudentStats"
+<Page x:Class="QuizClient.StudentStats"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-      xmlns:local="clr-namespace:QuizClient"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:oxy="http://oxyplot.org/wpf"
-      mc:Ignorable="d" 
+      mc:Ignorable="d"
       d:DesignHeight="450" d:DesignWidth="800"
       Title="StudentStats">
 
     <Grid>
-        <!-- DataGrid per le statistiche aggregate -->
-        <DataGrid x:Name="StudentStatsDataGrid" HorizontalAlignment="Left" VerticalAlignment="Top" Width="760" Height="200" Margin="20,20,20,0"/>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="150" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
-        <!-- Grafico dell'andamento temporale -->
-        <oxy:PlotView x:Name="StudentTimelineChart" HorizontalAlignment="Left" VerticalAlignment="Top" Width="760" Height="200" Margin="20,240,20,20"/>
+        <!-- Menu laterale -->
+        <StackPanel Grid.Column="0" Background="#EFEFEF">
+            <Button Content="Informazioni" Margin="10" Click="InfoButton_Click" />
+            <Button Content="Prestazioni" Margin="10" Click="PerformanceButton_Click" />
+            <Button Content="Andamento" Margin="10" Click="TimelineButton_Click" />
+        </StackPanel>
+
+        <!-- Contenuto principale -->
+        <Grid Grid.Column="1" Margin="10">
+            <!-- Informazioni personali -->
+            <Grid x:Name="InfoPanel" Visibility="Visible">
+                <StackPanel>
+                    <TextBlock Text="Informazioni Studente" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Nome:" Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5" />
+                        <TextBlock x:Name="NameText" Grid.Row="0" Grid.Column="1" />
+                        <TextBlock Text="Email:" Grid.Row="1" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5" />
+                        <TextBlock x:Name="EmailText" Grid.Row="1" Grid.Column="1" />
+                        <TextBlock Text="Data Nascita:" Grid.Row="2" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5" />
+                        <TextBlock x:Name="BirthDateText" Grid.Row="2" Grid.Column="1" />
+                        <TextBlock Text="Genere:" Grid.Row="3" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,0" />
+                        <TextBlock x:Name="GenderText" Grid.Row="3" Grid.Column="1" />
+                    </Grid>
+                </StackPanel>
+            </Grid>
+
+            <!-- Prestazioni per categoria/difficolta -->
+            <Grid x:Name="PerformancePanel" Visibility="Collapsed">
+                <StackPanel>
+                    <TextBlock Text="Prestazioni per Categoria/Difficolta" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
+                    <DataGrid x:Name="StudentStatsDataGrid" AutoGenerateColumns="True" />
+                </StackPanel>
+            </Grid>
+
+            <!-- Andamento temporale -->
+            <Grid x:Name="TimelinePanel" Visibility="Collapsed">
+                <StackPanel>
+                    <TextBlock Text="Andamento Temporale" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
+                    <oxy:PlotView x:Name="StudentTimelineChart" Height="300" />
+                </StackPanel>
+            </Grid>
+        </Grid>
     </Grid>
 </Page>

--- a/QuizClient/QuizClient/StudentStats.xaml.cs
+++ b/QuizClient/QuizClient/StudentStats.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using OxyPlot;
 using OxyPlot.Series;
 using QuizClient.Services;
+using QuizClient.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +23,9 @@ namespace QuizClient
     public partial class StudentStats : Page
     {
         private readonly AnalyticsService analyticsService;
-        private string _jwtToken; // Token JWT per autenticazione
+        private readonly string _jwtToken; // Token JWT per autenticazione
+        private StudentStatsResponse? _stats;
+
         public StudentStats(string jwtToken)
         {
             InitializeComponent();
@@ -30,7 +33,7 @@ namespace QuizClient
             _jwtToken = jwtToken;
             analyticsService = new AnalyticsService(_jwtToken); // Inizializza il servizio con il token JWT
             LoadStudentStats();
-            
+
         }
 
         private async void LoadStudentStats()
@@ -43,13 +46,20 @@ namespace QuizClient
                 return;
             }
 
-            var studentStats = result.Data; // Ottieni i dati delle statistiche dello studente
+            _stats = result.Data; // Salva i dati delle statistiche dello studente
+
+            // Popola info personali
+            var studente = _stats.Studente;
+            NameText.Text = $"{studente.Nome} {studente.Cognome}";
+            EmailText.Text = studente.Email;
+            BirthDateText.Text = studente.DataNascita.ToShortDateString();
+            GenderText.Text = studente.Genere;
 
             // Popola il DataGrid con le statistiche per categoria e difficoltà
-            StudentStatsDataGrid.ItemsSource = studentStats.StatsPerCategoriaDifficolta;
+            StudentStatsDataGrid.ItemsSource = _stats.StatsPerCategoriaDifficolta;
 
             // Imposta i dati per il grafico temporale
-            var timelineData = studentStats.AndamentoTemporale;
+            var timelineData = _stats.AndamentoTemporale;
             var plotModel = new PlotModel { Title = "Andamento Temporale" };
 
             // Aggiungiamo le serie per "Corrette", "Sbagliate" e "Non Date"
@@ -88,6 +98,27 @@ namespace QuizClient
 
             // Impostiamo il grafico
             StudentTimelineChart.Model = plotModel;
+        }
+
+        private void InfoButton_Click(object sender, RoutedEventArgs e)
+        {
+            InfoPanel.Visibility = Visibility.Visible;
+            PerformancePanel.Visibility = Visibility.Collapsed;
+            TimelinePanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void PerformanceButton_Click(object sender, RoutedEventArgs e)
+        {
+            InfoPanel.Visibility = Visibility.Collapsed;
+            PerformancePanel.Visibility = Visibility.Visible;
+            TimelinePanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void TimelineButton_Click(object sender, RoutedEventArgs e)
+        {
+            InfoPanel.Visibility = Visibility.Collapsed;
+            PerformancePanel.Visibility = Visibility.Collapsed;
+            TimelinePanel.Visibility = Visibility.Visible;
         }
     }
 


### PR DESCRIPTION
## Summary
- redesign StudentStats page with side menu
- display student info, performance and timeline in separate panels
- handle button clicks to switch panels

## Testing
- `dotnet build QuizClient/QuizClient/QuizClient.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7bc95a84832bad8e1144d33ae3c0