### PR TITLE
Port GUI to Avalonia

### DIFF
--- a/TestGeneratorClient/MainWindow.axaml
+++ b/TestGeneratorClient/MainWindow.axaml
@@ -4,6 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="TestGeneratorClient.MainWindow"
-        Title="TestGeneratorClient">
-    Welcome to Avalonia!
+        Title="Quiz Multiplayer">
+    <ContentControl x:Name="MainContent" />
 </Window>

--- a/TestGeneratorClient/MainWindow.axaml.cs
+++ b/TestGeneratorClient/MainWindow.axaml.cs
@@ -7,5 +7,11 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        MainContent.Content = new Views.LoginPage(this);
+    }
+
+    public void Navigate(Control control)
+    {
+        MainContent.Content = control;
     }
 }

--- a/TestGeneratorClient/Models/OutputDataModels.cs
+++ b/TestGeneratorClient/Models/OutputDataModels.cs
@@ -1,0 +1,168 @@
+using System.Text.Json.Serialization;
+
+namespace TestGeneratorClient.Models
+{
+    // Classi che rispecchiano le strutture dei JSON restituiti dal server: C# client <-- JSON -- Server
+    public class Quiz
+    {
+        [JsonPropertyName("titolo")]
+        public string Titolo { get; set; } = "";
+
+        
+        [JsonPropertyName("difficolta")]
+        public string Difficolta { get; set; } = "";
+
+        [JsonPropertyName("quantita")]
+        public int Quantita { get; set; } = 0 ;
+
+        [JsonPropertyName("quesiti")]
+        public List<Quesito> Quesiti { get; set; } = new();
+        
+        
+        [JsonPropertyName("ai_generated")]
+        public bool AiGenerated { get; set; }
+        
+    }
+
+    public class Quesito
+    {
+        [JsonPropertyName("id")]
+        public uint ID { get; set; }
+
+        [JsonPropertyName("difficolta")]
+        public string Difficolta { get; set; } = "";
+
+        [JsonPropertyName("testo")]
+        public string Testo { get; set; } = "";
+
+        [JsonPropertyName("opzione_a")]
+        public string OpzioneA { get; set; } = "";
+
+        [JsonPropertyName("opzione_b")]
+        public string OpzioneB { get; set; } = "";
+
+        [JsonPropertyName("opzione_c")]
+        public string OpzioneC { get; set; } = "";
+
+        [JsonPropertyName("opzione_d")]
+        public string OpzioneD { get; set; } = "";
+
+        [JsonPropertyName("op_corretta")]
+        public int OpCorretta { get; set; }
+
+        [JsonPropertyName("id_docente")]
+        public uint IDDocente { get; set; }
+
+        [JsonPropertyName("docente")]
+        public Utente Docente { get; set; } = new Utente();
+
+        [JsonPropertyName("categorie")]
+        public List<Categoria> Categorie { get; set; } = new();
+    }
+
+
+    public class Utente
+    {
+        [JsonPropertyName("id")]
+        public uint ID { get; set; }
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; } = "";
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; } = "";
+
+        [JsonPropertyName("nome")]
+        public string Nome { get; set; } = "";
+
+        [JsonPropertyName("cognome")]
+        public string Cognome { get; set; } = "";
+
+        [JsonPropertyName("data_nascita")]
+        public DateTime DataNascita { get; set; }
+
+        [JsonPropertyName("genere")]
+        public string Genere { get; set; } = "";
+
+        [JsonPropertyName("ruolo")]
+        public string Ruolo { get; set; } = "";
+
+        [JsonPropertyName("quesiti")]
+        public List<Quesito>? Quesiti { get; set; }
+
+        [JsonPropertyName("categorie")]
+        public List<Categoria>? Categorie { get; set; }
+    }
+
+    public class Categoria
+    {
+        [JsonPropertyName("id")]
+        public uint ID { get; set; }
+
+        [JsonPropertyName("tipo")]
+        public string Tipo { get; set; } = "";
+
+        [JsonPropertyName("nome")]
+        public string Nome { get; set; } = "";
+
+        [JsonPropertyName("descrizione")]
+        public string Descrizione { get; set; } = "";
+
+        [JsonPropertyName("id_docente")]
+        public uint IDDocente { get; set; }
+
+        [JsonPropertyName("pubblica")]
+        public bool Pubblica { get; set; }
+
+        [JsonPropertyName("docente")]
+        public Utente? Docente { get; set; }
+
+        [JsonPropertyName("quesiti")]
+        public List<Quesito>? Quesiti { get; set; }
+
+        public bool Selezionata { get; set; } // Per bind alla checkbox
+    }
+
+
+
+    // Modello per la risposta del server quando si richiedono le statistiche di uno studente
+    public class StudentStatsResponse
+    {
+        [JsonPropertyName("studente")]
+        public Utente Studente { get; set; } = new();
+
+        [JsonPropertyName("stats_per_categoria_difficolta")]
+        public List<StatsPerCategoriaDifficolta> StatsPerCategoriaDifficolta { get; set; } = new();
+
+        [JsonPropertyName("andamento_temporale")]
+        public List<TimelineData> AndamentoTemporale { get; set; } = new();
+    }
+
+
+
+    public class StatsPerCategoriaDifficolta
+    {
+        [JsonPropertyName("categoria")]
+        public string Categoria { get; set; } = "";
+        [JsonPropertyName("difficolta")]
+        public string Difficolta { get; set; } = "";
+        [JsonPropertyName("corrette")]
+        public int Corrette { get; set; }
+        [JsonPropertyName("sbagliate")]
+        public int Sbagliate { get; set; }
+        [JsonPropertyName("non_date")]
+        public int NonDate { get; set; }
+    }
+
+    public class TimelineData
+    {
+        [JsonPropertyName("date")]
+        public DateTime Date { get; set; }
+        [JsonPropertyName("corrette")]
+        public int Corrette { get; set; }
+        [JsonPropertyName("sbagliate")]
+        public int Sbagliate { get; set; }
+        [JsonPropertyName("non_date")]
+        public int NonDate { get; set; }
+    }
+}

--- a/TestGeneratorClient/Services/AnalyticsService.cs
+++ b/TestGeneratorClient/Services/AnalyticsService.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using QuizClient.Models;
+using QuizClient.Utils;
+using System.Net.Http.Json;
+
+namespace TestGeneratorClient.Services
+{
+    public class AnalyticsService
+    {
+        private readonly HttpClient _client;
+        private readonly string _jwtToken;
+
+        public AnalyticsService(string jwtToken)
+        {
+            _client = new HttpClient();
+            _client.BaseAddress = new Uri("http://localhost:8005"); // modifica se usi altra porta
+            _jwtToken = jwtToken;
+            // Imposta l'header di autorizzazione delle richieste http che verranno inviate da questo client con il token JWT
+            _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+        }
+
+        public async Task<ServiceResult<StudentStatsResponse>> GetStudentStatsAsync()
+        {
+            try
+            {
+                var id_studente = JwtUtils.GetClaimAsUInt(_jwtToken, "user_id");
+                var response = await _client.GetAsync($"/stats/student/{id_studente}");
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<StudentStatsResponse>();
+                    return new ServiceResult<StudentStatsResponse> { Data = data };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = System.Text.Json.JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch { }
+                    return new ServiceResult<StudentStatsResponse> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<StudentStatsResponse> { ErrorMessage = $"Errore di rete: {ex.Message}"};
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<StudentStatsResponse> { ErrorMessage = $"Errore imprevisto: {ex.Message}"};
+            }
+        }
+    }
+}

--- a/TestGeneratorClient/Services/AuthService.cs
+++ b/TestGeneratorClient/Services/AuthService.cs
@@ -1,0 +1,67 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace TestGeneratorClient.Services
+{
+    public class AuthService
+    {
+        private readonly HttpClient _client;
+
+        public AuthService()
+        {
+            _client = new HttpClient();
+            _client.BaseAddress = new Uri("http://localhost:8000"); // modifica se usi altra porta
+        }
+
+        public async Task<string?> LoginAsync(string email, string password)
+        {
+            var data = new { email, password };
+            var response = await _client.PostAsJsonAsync("/auth/login", data);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadFromJsonAsync<LoginResponse>();
+                return json?.AccessToken;
+            }
+
+            return null;
+        }
+
+        // i nomi dei campi del json inviato dal client al server Uvicorn assieme alla richiesta http
+        // devono combaciare con quelli definiti tramite le classi Pydanitc, nel file schemas.py di auth_service
+        public async Task<(bool Success, string Message)> RegisterAsync(string ruolo, string username, string email, string nome, string cognome, string genere, string password, string data_nascita)
+        {
+            var data = new
+            {
+                ruolo,
+                username,
+                email,
+                nome,
+                cognome,
+                genere,
+                password,
+                data_nascita
+            };
+            var response = await _client.PostAsJsonAsync("/auth/register", data);
+            if (response.IsSuccessStatusCode)
+            {
+                return (true, "Registrazione completata per: " + username);
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                return (false, "Errore: " + error);
+            }
+        }
+    }
+
+    public class LoginResponse
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = "";
+
+        [System.Text.Json.Serialization.JsonPropertyName("token_type")]
+        public string TokenType { get; set; } = "";
+    }
+}

--- a/TestGeneratorClient/Services/CRUDService.cs
+++ b/TestGeneratorClient/Services/CRUDService.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using QuizClient.Models;
+using QuizClient.Utils;
+
+namespace TestGeneratorClient.Services
+{
+    internal class CRUDService
+    {
+        private readonly HttpClient _client;
+        private readonly string _jwtToken;
+
+        public CRUDService(string jwtToken)
+        {
+            _client = new HttpClient();
+            _client.BaseAddress = new Uri("http://localhost:8082"); // Modifica se usi un'altra porta
+            _jwtToken = jwtToken;
+            // Imposta l'header di autorizzazione delle richieste http che verranno inviate da questo client con il token JWT
+            _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwtToken);
+        }
+
+
+        public async Task<ServiceResult<List<Categoria>>> GetCategoriePubblicheAsync()
+        {
+            try
+            {
+                var response = await _client.GetAsync("/categorie/pubbliche");
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<List<Categoria>>() ?? new List<Categoria>();
+                    return new ServiceResult<List<Categoria>> { Data = data };
+                }
+                else
+                {
+                    // Legge il contenuto della risposta HTTP come stringa (di solito JSON con dettagli dell'errore)
+                    var error = await response.Content.ReadAsStringAsync();
+                    // Prepara un messaggio di errore generico con il codice di stato HTTP
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        // Prova a interpretare la stringa come JSON
+                        using var doc = JsonDocument.Parse(error);
+                        // Se il JSON contiene una proprietà "error", usa il suo valore come messaggio di errore
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch
+                    {
+                        // Se il parsing fallisce, mantiene il messaggio di errore generico
+                    }
+                    return new ServiceResult<List<Categoria>> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<List<Categoria>> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<List<Categoria>> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+        public async Task<ServiceResult<List<Categoria>>> GetCategorieByDocenteAsync()
+        {
+            try
+            {
+
+                var id_docente = JwtUtils.GetClaimAsUInt(_jwtToken, "user_id");
+
+                var response = await _client.GetAsync($"/categorie/docente/{id_docente}");
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<List<Categoria>>() ?? new List<Categoria>();
+                    return new ServiceResult<List<Categoria>> { Data = data };
+                }
+                else
+                {
+                    // Legge il contenuto della risposta HTTP come stringa (di solito JSON con dettagli dell'errore)
+                    var error = await response.Content.ReadAsStringAsync();
+
+                    // Prepara un messaggio di errore generico con il codice di stato HTTP
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        // Prova a interpretare la stringa come JSON
+                        using var doc = JsonDocument.Parse(error);
+
+                        // Se il JSON contiene una proprietà "error", usa il suo valore come messaggio di errore
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch
+                    {
+                        // Se il parsing fallisce, mantiene il messaggio di errore generico
+                    }
+                    return new ServiceResult<List<Categoria>> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<List<Categoria>> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<List<Categoria>> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+
+        public async Task<ServiceResult<Categoria>> CreateCategoriaAsync(Categoria categoria)
+        {
+            try
+            {
+                var response = await _client.PostAsJsonAsync("/categorie/create", categoria);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<Categoria>();
+                    return new ServiceResult<Categoria> { Data = data };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch
+                    {
+                    }
+                    return new ServiceResult<Categoria> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<Categoria> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<Categoria> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+
+        public async Task<ServiceResult<Categoria>> UpdateCategoriaAsync(Categoria categoria)
+        {
+            try
+            {
+                var response = await _client.PutAsJsonAsync($"/categorie/update", categoria);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<Categoria>();
+                    return new ServiceResult<Categoria> { Data = data };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch
+                    {
+                    }
+                    return new ServiceResult<Categoria> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<Categoria> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<Categoria> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+
+
+
+        public async Task<ServiceResult<bool>> DeleteCategoriaAsync(List<uint> ids)
+        {
+            try
+            {
+                // Non esiste un metodo DeleteAsJsonAsync, quindi si usa HttpRequestMessage per inviare una richiesta DELETE con il corpo JSON
+                var request = new HttpRequestMessage(HttpMethod.Delete, "/categorie/delete")
+                {
+                    Content = JsonContent.Create(ids) // ids è la lista di ID da inviare
+                };
+                var response = await _client.SendAsync(request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return new ServiceResult<bool> { Data = true };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch
+                    {
+                    }
+                    return new ServiceResult<bool> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<bool> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<bool> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+    }
+}

--- a/TestGeneratorClient/Services/QuizService.cs
+++ b/TestGeneratorClient/Services/QuizService.cs
@@ -1,0 +1,131 @@
+using QuizClient.Models;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using QuizClient.Utils;
+
+namespace TestGeneratorClient.Services
+{
+    public class QuizService
+    {
+        private readonly HttpClient _client;
+        private readonly string _jwtToken;
+
+        public QuizService(string jwtToken)
+        {
+            _client = new HttpClient();
+            _client.BaseAddress = new Uri("http://localhost:8081"); // modifica se usi altra porta
+            _jwtToken = jwtToken;
+
+            // Imposta l'header di autorizzazione delle richieste http che verranno inviate da questo client con il token JWT
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwtToken);
+        }
+
+        // Crea quiz
+        public async Task<ServiceResult<Quiz>> CreateQuizAsync(bool AIg, string AIcat, List<int> id_cat, bool u, string diff, int nd)
+        {
+            var quiz_data = new
+            {
+                ai_generated = AIg,
+                ai_categoria = AIcat,
+                id_categorie = id_cat,
+                unione = u,
+                difficolta = diff,
+                quantita = nd,
+            };
+            try
+            {
+                var response = await _client.PostAsJsonAsync("/quiz/create", quiz_data);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<Quiz>();
+                    return new ServiceResult<Quiz> { Data = data };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch { }
+                    return new ServiceResult<Quiz> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<Quiz> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<Quiz> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+
+        public async Task<ServiceResult<Quiz>> StoreQuizAsync(Quiz q, int corrette, int sbagliate, string data_creazione, string durata, List<int?> risposte_utente) { 
+
+            try
+            {
+                // Prelevo l'id dll'utente dal token JWT
+                uint id_utente = JwtUtils.GetClaimAsUInt(_jwtToken, "user_id");
+
+                // Preparo la lista di id dei quesiti del quiz (non serve inviare al server l'oggetto Quesito completo, ma solo gli ID)
+                List<uint> id_quesiti = q.Quesiti.Select(quesito => quesito.ID).ToList();
+
+                // Creo l'oggetto da inviare al server
+                var quiz_data = new
+                {
+                    difficolta = q.Difficolta,
+                    quantita = q.Quantita,
+                    id_quesiti,
+                    id_utente,
+                    corrette,
+                    sbagliate,
+                    data_creazione,
+                    durata,
+                    risposte_utente
+
+                };
+
+
+                var response = await _client.PostAsJsonAsync("/quiz/store", quiz_data);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = await response.Content.ReadFromJsonAsync<Quiz>();
+                    return new ServiceResult<Quiz> { Data = data };
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    string? errorMsg = $"Errore HTTP {response.StatusCode}";
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(error);
+                        if (doc.RootElement.TryGetProperty("error", out var errorProp))
+                            errorMsg = errorProp.GetString() ?? errorMsg;
+                    }
+                    catch { }
+                    return new ServiceResult<Quiz> { ErrorMessage = errorMsg };
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ServiceResult<Quiz> { ErrorMessage = $"Errore di rete: {ex.Message}" };
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult<Quiz> { ErrorMessage = $"Errore imprevisto: {ex.Message}" };
+            }
+        }
+    }
+ 
+}

--- a/TestGeneratorClient/TestGeneratorClient.csproj
+++ b/TestGeneratorClient/TestGeneratorClient.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="MessageBox.Avalonia" Version="0.10.11" />
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>

--- a/TestGeneratorClient/Utils/JwtUtils.cs
+++ b/TestGeneratorClient/Utils/JwtUtils.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace TestGeneratorClient.Utils
+{
+    public static class JwtUtils
+    {
+        public static string GetClaimAsString(string jwt, string claimName)
+        {
+            if (string.IsNullOrEmpty(jwt))
+                throw new ArgumentNullException(nameof(jwt), "Il token JWT non può essere nullo o vuoto.");
+
+            var parts = jwt.Split('.');
+            if (parts.Length != 3)
+                throw new ArgumentException("Il token JWT non è in un formato valido.", nameof(jwt));
+
+            var payload = parts[1];
+            switch (payload.Length % 4)
+            {
+                case 2: payload += "=="; break;
+                case 3: payload += "="; break;
+            }
+
+            var bytes = Convert.FromBase64String(payload.Replace('-', '+').Replace('_', '/'));
+            var json = Encoding.UTF8.GetString(bytes);
+            using var doc = JsonDocument.Parse(json);
+
+            if (doc.RootElement.TryGetProperty(claimName, out var value))
+            {
+                var str = value.GetString();
+                if (str is not null)
+                    return str;
+            }
+
+            throw new InvalidOperationException($"Claim '{claimName}' non trovata o non convertibile in stringa.");
+        }
+
+        public static uint GetClaimAsUInt(string jwt, string claimName)
+        {
+            if (string.IsNullOrEmpty(jwt))
+                throw new ArgumentNullException(nameof(jwt), "Il token JWT non può essere nullo o vuoto.");
+
+            var parts = jwt.Split('.');
+            if (parts.Length != 3)
+                throw new ArgumentException("Il token JWT non è in un formato valido.", nameof(jwt));
+
+            var payload = parts[1];
+            switch (payload.Length % 4)
+            {
+                case 2: payload += "=="; break;
+                case 3: payload += "="; break;
+            }
+            var bytes = Convert.FromBase64String(payload.Replace('-', '+').Replace('_', '/'));
+            var json = Encoding.UTF8.GetString(bytes);
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty(claimName, out var value))
+            {
+                if (value.ValueKind == JsonValueKind.Number && value.TryGetUInt32(out uint uintValue))
+                    return uintValue;
+                if (value.ValueKind == JsonValueKind.String && uint.TryParse(value.GetString(), out uint uintFromString))
+                    return uintFromString;
+            }
+            throw new InvalidOperationException($"Claim '{claimName}' non trovata o non convertibile in uint.");
+        }
+
+        public static async void ValidateDocenteRole(string jwt, object? navigationService, Control control)
+        {
+            bool isDocente = false;
+            try{ var ruolo = GetClaimAsString(jwt, "ruolo"); isDocente = ruolo == "Docente"; } catch{ isDocente = false; }
+            if(!isDocente){ await MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow("Accesso negato","Accesso non autorizzato. Solo i docenti possono visualizzare questa pagina.").ShowDialog((Window)control.VisualRoot!); if(control is Window win){ win.Close(); } else { control.IsEnabled=false; } }
+        }
+    }
+}

--- a/TestGeneratorClient/Utils/PubblicaToStringConverter.cs
+++ b/TestGeneratorClient/Utils/PubblicaToStringConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace TestGeneratorClient.Utils
+{
+    public class PubblicaToStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (value is bool b && b) ? "Pubblica" : "Privata";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TestGeneratorClient/Utils/ServiceResult.cs
+++ b/TestGeneratorClient/Utils/ServiceResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestGeneratorClient.Utils
+{
+    public class ServiceResult<T>
+    {
+        public T? Data { get; set; }
+        public bool Success => ErrorMessage == null;
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/TestGeneratorClient/Utils/SessionManager.cs
+++ b/TestGeneratorClient/Utils/SessionManager.cs
@@ -1,0 +1,7 @@
+namespace TestGeneratorClient.Utils
+{
+    public static class SessionManager
+    {
+        public static string? AccessToken { get; set; }
+    }
+}

--- a/TestGeneratorClient/Views/CategoryDialogWindow.axaml
+++ b/TestGeneratorClient/Views/CategoryDialogWindow.axaml
@@ -1,0 +1,39 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="TestGeneratorClient.Views.CategoryDialogWindow"
+        Width="800" Height="450" WindowStartupLocation="CenterScreen" Title="Category">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Compila la categoria" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
+        <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Nome:" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <TextBox x:Name="NomeBox" Grid.Row="0" Grid.Column="1"/>
+            <TextBlock Text="Tipo:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <TextBox x:Name="TipoBox" Grid.Row="1" Grid.Column="1"/>
+            <TextBlock Text="Descrizione:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Margin="0,0,10,0"/>
+            <TextBox x:Name="DescrizioneBox" Grid.Row="2" Grid.Column="1" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="0,10,0,0">
+                <RadioButton x:Name="PubblicaRadio" Content="Pubblica" GroupName="Visibilita" Margin="0,0,20,0"/>
+                <RadioButton x:Name="PrivataRadio" Content="Privata" GroupName="Visibilita"/>
+            </StackPanel>
+        </Grid>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+            <Button Content="Salva" Width="80" Margin="5" Click="Salva_Click"/>
+            <Button Content="Annulla" Width="80" Margin="5" Click="Annulla_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/TestGeneratorClient/Views/CategoryDialogWindow.axaml.cs
+++ b/TestGeneratorClient/Views/CategoryDialogWindow.axaml.cs
@@ -1,0 +1,78 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Models;
+using TestGeneratorClient.Utils;
+
+namespace TestGeneratorClient.Views;
+
+public partial class CategoryDialogWindow : Window
+{
+    public Categoria CategoriaCreata { get; private set; } = new();
+    private readonly string _jwtToken;
+
+    public CategoryDialogWindow(string tk)
+    {
+        _jwtToken = tk;
+        InitializeComponent();
+        JwtUtils.ValidateDocenteRole(_jwtToken, null, this);
+    }
+
+    public CategoryDialogWindow(Categoria esistente, string tk) : this(tk)
+    {
+        NomeBox.Text = esistente.Nome;
+        TipoBox.Text = esistente.Tipo;
+        DescrizioneBox.Text = esistente.Descrizione;
+        PubblicaRadio.IsChecked = esistente.Pubblica;
+        PrivataRadio.IsChecked = !esistente.Pubblica;
+        CategoriaCreata = new Categoria
+        {
+            ID = esistente.ID,
+            Nome = esistente.Nome,
+            Tipo = esistente.Tipo,
+            Descrizione = esistente.Descrizione,
+            Pubblica = esistente.Pubblica,
+            IDDocente = esistente.IDDocente,
+            Docente = esistente.Docente,
+            Quesiti = esistente.Quesiti
+        };
+    }
+
+    private void Salva_Click(object? sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(NomeBox.Text) || string.IsNullOrWhiteSpace(DescrizioneBox.Text) ||
+            (PubblicaRadio.IsChecked != true && PrivataRadio.IsChecked != true))
+        {
+            MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore", "Compila tutti i campi obbligatori")
+                .ShowDialog(this);
+            return;
+        }
+
+        uint idDocente;
+        try
+        {
+            idDocente = JwtUtils.GetClaimAsUInt(_jwtToken, "user_id");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore JWT", $"Errore nel recupero dell'ID docente dal token JWT: {ex.Message}")
+                .ShowDialog(this);
+            return;
+        }
+
+        CategoriaCreata.Nome = NomeBox.Text.Trim();
+        CategoriaCreata.Tipo = TipoBox.Text.Trim();
+        CategoriaCreata.Descrizione = DescrizioneBox.Text.Trim();
+        CategoriaCreata.Pubblica = PubblicaRadio.IsChecked == true;
+        CategoriaCreata.IDDocente = idDocente;
+        DialogResult = true;
+        Close();
+    }
+
+    private void Annulla_Click(object? sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/TestGeneratorClient/Views/CategorySelectionWindow.axaml
+++ b/TestGeneratorClient/Views/CategorySelectionWindow.axaml
@@ -1,0 +1,49 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="TestGeneratorClient.Views.CategorySelectionWindow"
+        Width="600" Height="500" Title="Seleziona Categorie">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+            <TextBlock Text="Cerca:" VerticalAlignment="Center"/>
+            <TextBox x:Name="SearchBox" Width="200" Margin="5 0" TextChanged="SearchBox_TextChanged"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Vertical" Margin="0 0 0 10">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Modalità filtro categorie:" FontWeight="Bold" Margin="0,10,10,5" VerticalAlignment="Center"/>
+                <RadioButton x:Name="UnionOption" Content="Unione" GroupName="CategoryMode" IsChecked="True" Margin="0,10,10,5" VerticalAlignment="Center"/>
+                <RadioButton x:Name="IntersectionOption" Content="Intersezione" GroupName="CategoryMode" Margin="0,10,0,5" VerticalAlignment="Center"/>
+            </StackPanel>
+            <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="Gray" Margin="0,5,0,0">
+                <Run Text="- Unione: le domande possono appartenere a una qualsiasi delle categorie selezionate."/>
+                <LineBreak/>
+                <Run Text="- Intersezione: le domande devono appartenere a tutte le categorie selezionate."/>
+            </TextBlock>
+        </StackPanel>
+        <ListView Grid.Row="2" x:Name="CategoryListView">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="✓" Width="40">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding Selezionata}"/>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="Nome" DisplayMemberBinding="{Binding Nome}" Width="200"/>
+                    <GridViewColumn Header="Tipo" DisplayMemberBinding="{Binding Tipo}" Width="100"/>
+                    <GridViewColumn Header="Creatore" DisplayMemberBinding="{Binding Docente.Username}" Width="150"/>
+                </GridView>
+            </ListView.View>
+        </ListView>
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0 10 0 0">
+            <Button Content="Annulla" Width="80" Margin="5" Click="Annulla_Click"/>
+            <Button Content="Conferma" Width="100" Margin="5" Click="Conferma_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/TestGeneratorClient/Views/CategorySelectionWindow.axaml.cs
+++ b/TestGeneratorClient/Views/CategorySelectionWindow.axaml.cs
@@ -1,0 +1,65 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Models;
+using TestGeneratorClient.Services;
+using TestGeneratorClient.Utils;
+using System.Collections.ObjectModel;
+
+namespace TestGeneratorClient.Views;
+
+public partial class CategorySelectionWindow : Window
+{
+    private List<Categoria> _tutteLeCategorie = new();
+    private ObservableCollection<Categoria> _categorieFiltrate = new();
+    public List<Categoria>? Selezionate { get; private set; }
+    public bool Unione { get; set; }
+    private readonly CRUDService _CRUDService;
+    private readonly string _jwtToken;
+
+    public CategorySelectionWindow(string jwt)
+    {
+        InitializeComponent();
+        _jwtToken = jwt;
+        _CRUDService = new CRUDService(_jwtToken);
+        CaricaCategorie();
+    }
+
+    private async void CaricaCategorie()
+    {
+        var result = await _CRUDService.GetCategoriePubblicheAsync();
+        if (result.Success && result.Data != null)
+        {
+            _tutteLeCategorie = result.Data;
+            FiltraCategorie(SearchBox.Text);
+        }
+        else
+        {
+            await MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore", result.ErrorMessage ?? "Errore nel caricamento delle categorie.")
+                .ShowDialog(this);
+            Close();
+        }
+    }
+
+    private void FiltraCategorie(string filtro)
+    {
+        _categorieFiltrate.Clear();
+        foreach (var cat in _tutteLeCategorie.Where(c => c.Pubblica && (string.IsNullOrWhiteSpace(filtro) || c.Nome.Contains(filtro, System.StringComparison.OrdinalIgnoreCase))))
+        {
+            _categorieFiltrate.Add(cat);
+        }
+        CategoryListView.ItemsSource = null;
+        CategoryListView.ItemsSource = _categorieFiltrate;
+    }
+
+    private void SearchBox_TextChanged(object? sender, RoutedEventArgs e) => FiltraCategorie(SearchBox.Text ?? string.Empty);
+    private void Annulla_Click(object? sender, RoutedEventArgs e) => Close();
+
+    private void Conferma_Click(object? sender, RoutedEventArgs e)
+    {
+        Unione = UnionOption.IsChecked == true;
+        Selezionate = _categorieFiltrate.Where(c => c.Selezionata).ToList();
+        DialogResult = true;
+        Close();
+    }
+}

--- a/TestGeneratorClient/Views/CreateQuizPage.axaml
+++ b/TestGeneratorClient/Views/CreateQuizPage.axaml
@@ -1,0 +1,39 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TestGeneratorClient.Views.CreateQuizPage">
+    <Grid Margin="20" Background="White">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Width="320" Margin="40">
+            <TextBlock Text="Crea quiz" FontSize="24" Margin="0,0,0,20"/>
+            <TextBlock Text="Compila i campi per generare un nuovo quiz:" Margin="0,0,0,20"/>
+            <TextBlock Text="Vuoi che il quiz sia generato dall'AI?"/>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                <RadioButton x:Name="AIGeneratedYes" Content="Sì" GroupName="AIGenerated" IsChecked="False" Checked="AIGenerated_Checked"/>
+                <RadioButton x:Name="AIGeneratedNo" Content="No" GroupName="AIGenerated" IsChecked="True" Margin="20,0,0,0" Checked="AIGenerated_Checked"/>
+            </StackPanel>
+            <TextBlock x:Name="CategorieSelezionateLabel" Text="Categorie selezionate" IsVisible="True"/>
+            <DockPanel Margin="0,0,0,10">
+                <TextBox x:Name="CategoryBox" IsReadOnly="True" Width="220" IsVisible="True"/>
+                <Button Content="Scegli" Width="80" Margin="5,0,0,0" Click="ApriSelezioneCategorie_Click" IsVisible="True"/>
+            </DockPanel>
+            <StackPanel IsVisible="False" x:Name="AICategoryPanel">
+                <TextBlock x:Name="AICategoryText" Text="Inserisci categoria"/>
+                <TextBox x:Name="AICategoryBox" Margin="0,0,0,10"/>
+            </StackPanel>
+            <TextBlock Text="Numero di domande"/>
+            <TextBox x:Name="NumQuestionsBox" Margin="0,0,0,10"/>
+            <TextBlock Text="Difficoltà"/>
+            <ComboBox x:Name="DifficultyBox" Margin="0,0,0,10">
+                <ComboBoxItem Content="Facile"/>
+                <ComboBoxItem Content="Intermedia"/>
+                <ComboBoxItem Content="Difficile"/>
+                <ComboBoxItem Content="Qualsiasi"/>
+            </ComboBox>
+            <Button Content="Crea Quiz" Click="CreateQuiz_Click" Margin="0,20,0,10"/>
+            <Button Content="Indietro" Click="Back_Click"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/TestGeneratorClient/Views/CreateQuizPage.axaml.cs
+++ b/TestGeneratorClient/Views/CreateQuizPage.axaml.cs
@@ -1,0 +1,92 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Models;
+using TestGeneratorClient.Services;
+using TestGeneratorClient.Utils;
+
+namespace TestGeneratorClient.Views;
+
+public partial class CreateQuizPage : UserControl
+{
+    private readonly MainWindow _mainWindow;
+    private readonly string _jwtToken;
+    private readonly QuizService _quizService;
+    private List<Categoria> _categorieSelezionate = new();
+    private bool _unione;
+
+    public CreateQuizPage(MainWindow mainWindow, string jwtToken)
+    {
+        InitializeComponent();
+        _mainWindow = mainWindow;
+        _jwtToken = jwtToken;
+        _quizService = new QuizService(jwtToken);
+    }
+
+    private async void CreateQuiz_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var idCategorie = _categorieSelezionate.Where(c => c != null).Select(c => (int)c.ID).ToList();
+            int quantita = int.TryParse(NumQuestionsBox.Text, out int q) ? q : 0;
+            string difficolta = (DifficultyBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "Qualsiasi";
+            bool aiGenerated = AIGeneratedYes.IsChecked == true;
+            string aiCategoria = aiGenerated ? AICategoryBox.Text : string.Empty;
+
+            var result = await _quizService.CreateQuizAsync(aiGenerated, aiCategoria, idCategorie, _unione, difficolta, quantita);
+            if (result != null && result.Success && result.Data != null)
+            {
+                await MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow("Successo", "Quiz creato con successo!").ShowDialog(_mainWindow);
+                _mainWindow.Navigate(new QuizPage(result.Data, _jwtToken, _mainWindow));
+            }
+            else
+            {
+                await MessageBox.Avalonia.MessageBoxManager
+                    .GetMessageBoxStandardWindow("Errore", result?.ErrorMessage ?? "Errore nella creazione del quiz.")
+                    .ShowDialog(_mainWindow);
+            }
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Avalonia.MessageBoxManager.GetMessageBoxStandardWindow("Errore", $"Errore: {ex.Message}").ShowDialog(_mainWindow);
+        }
+    }
+
+    private void AIGenerated_Checked(object? sender, RoutedEventArgs e)
+    {
+        bool isAI = AIGeneratedYes.IsChecked == true;
+        CategorieSelezionateLabel.IsVisible = !isAI;
+        CategoryBox.IsVisible = !isAI;
+        if (CategoryBox.Parent is DockPanel dp)
+        {
+            foreach (var child in dp.Children)
+            {
+                if (child is Button btn && (string?)btn.Content == "Scegli")
+                    btn.IsVisible = !isAI;
+            }
+        }
+        AICategoryPanel.IsVisible = isAI;
+    }
+
+    private void Back_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new LobbyPage(_mainWindow, _jwtToken));
+    }
+
+    private void ApriSelezioneCategorie_Click(object? sender, RoutedEventArgs e)
+    {
+        var selector = new CategorySelectionWindow(_jwtToken);
+        selector.ShowDialog(_mainWindow).ContinueWith(t =>
+        {
+            if (selector.DialogResult == true && selector.Selezionate != null)
+            {
+                _categorieSelezionate = selector.Selezionate;
+                _unione = selector.Unione;
+                CategoryBox.Text = string.Join(", ", _categorieSelezionate.Select(c => c.Nome));
+            }
+            else
+            {
+                CategoryBox.Text = string.Empty;
+            }
+        }, TaskScheduler.FromCurrentSynchronizationContext());
+    }
+}

--- a/TestGeneratorClient/Views/LobbyPage.axaml
+++ b/TestGeneratorClient/Views/LobbyPage.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TestGeneratorClient.Views.LobbyPage">
+    <Grid Background="#F0F0F0">
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="20">
+            <TextBlock Text="Benvenuto nella Lobby" FontSize="24" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,30"/>
+            <Button Content="Crea quiz" Width="200" Height="40" Click="CreateQuiz_Click"/>
+            <Button Content="Gestisci categorie" x:Name="GestisciCategorieButton" Width="200" Height="40" Click="ManageCategories_Click"/>
+            <Button Content="Statistiche profilo" Width="200" Height="40" Click="ProfileStats_Click"/>
+            <Button Content="Logout" Width="200" Height="40" Background="LightCoral" Click="Logout_Click"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/TestGeneratorClient/Views/LobbyPage.axaml.cs
+++ b/TestGeneratorClient/Views/LobbyPage.axaml.cs
@@ -1,0 +1,53 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Utils;
+
+namespace TestGeneratorClient.Views;
+
+public partial class LobbyPage : UserControl
+{
+    private readonly MainWindow _mainWindow;
+    private readonly string _jwtToken;
+
+    public LobbyPage(MainWindow mainWindow, string jwtToken)
+    {
+        InitializeComponent();
+        _mainWindow = mainWindow;
+        _jwtToken = jwtToken;
+
+        string ruolo;
+        try
+        {
+            ruolo = JwtUtils.GetClaimAsString(_jwtToken, "ruolo");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore JWT", $"Errore nel recupero del ruolo utente dal token JWT: {ex.Message}")
+                .ShowDialog(_mainWindow);
+            IsEnabled = false;
+            return;
+        }
+        GestisciCategorieButton.IsVisible = ruolo == "Docente";
+    }
+
+    private void CreateQuiz_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new CreateQuizPage(_mainWindow, _jwtToken));
+    }
+
+    private void ManageCategories_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new CategoriesPage(_jwtToken, _mainWindow));
+    }
+
+    private void ProfileStats_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new StudentStats(_jwtToken, _mainWindow));
+    }
+
+    private void Logout_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new LoginPage(_mainWindow));
+    }
+}

--- a/TestGeneratorClient/Views/LoginPage.axaml
+++ b/TestGeneratorClient/Views/LoginPage.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TestGeneratorClient.Views.LoginPage">
+    <Grid Background="#F0F0F0">
+        <StackPanel Margin="40">
+            <TextBlock Text="QUIZ MULTIGIOCATORE" FontSize="24" Margin="0,0,0,20"/>
+            <TextBlock Text="Email"/>
+            <TextBox x:Name="EmailBox" Margin="0,0,0,10"/>
+            <TextBlock Text="Password"/>
+            <TextBox x:Name="PasswordBox" Margin="0,0,0,20" PasswordChar='*'/>
+            <Button Content="Login" Click="Login_Click" Height="40" Margin="0,0,0,10"/>
+            <Button Content="Registrati" Click="Register_Click" Height="40"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/TestGeneratorClient/Views/LoginPage.axaml.cs
+++ b/TestGeneratorClient/Views/LoginPage.axaml.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Services;
+
+namespace TestGeneratorClient.Views;
+
+public partial class LoginPage : UserControl
+{
+    private readonly MainWindow _mainWindow;
+    private readonly AuthService _authService = new();
+
+    public LoginPage(MainWindow mainWindow)
+    {
+        InitializeComponent();
+        _mainWindow = mainWindow;
+    }
+
+    private async void Login_Click(object? sender, RoutedEventArgs e)
+    {
+        string email = EmailBox.Text ?? string.Empty;
+        string password = PasswordBox.Text ?? string.Empty;
+
+        var token = await _authService.LoginAsync(email, password);
+        if (token != null)
+        {
+            Utils.SessionManager.AccessToken = token;
+            _mainWindow.Navigate(new LobbyPage(_mainWindow, token));
+        }
+        else
+        {
+            await MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore", "Credenziali non valide.")
+                .ShowDialog(_mainWindow);
+        }
+    }
+
+    private void Register_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new RegisterPage(_mainWindow));
+    }
+}

--- a/TestGeneratorClient/Views/QuizPage.axaml
+++ b/TestGeneratorClient/Views/QuizPage.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TestGeneratorClient.Views.QuizPage">
+    <StackPanel Margin="40">
+        <TextBlock x:Name="TitleText" FontSize="24" FontWeight="Bold" Margin="0,0,0,20"/>
+        <Button Content="Torna alla lobby" Click="Back_Click" Width="200"/>
+    </StackPanel>
+</UserControl>

--- a/TestGeneratorClient/Views/QuizPage.axaml.cs
+++ b/TestGeneratorClient/Views/QuizPage.axaml.cs
@@ -1,0 +1,26 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Models;
+
+namespace TestGeneratorClient.Views;
+
+public partial class QuizPage : UserControl
+{
+    private readonly MainWindow _mainWindow;
+    private readonly string _jwt;
+    private readonly Quiz _quiz;
+
+    public QuizPage(Quiz quiz, string jwt, MainWindow mainWindow)
+    {
+        InitializeComponent();
+        _quiz = quiz;
+        _jwt = jwt;
+        _mainWindow = mainWindow;
+        TitleText.Text = quiz.Titolo;
+    }
+
+    private void Back_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new LobbyPage(_mainWindow, _jwt));
+    }
+}

--- a/TestGeneratorClient/Views/RegisterPage.axaml
+++ b/TestGeneratorClient/Views/RegisterPage.axaml
@@ -1,0 +1,38 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="TestGeneratorClient.Views.RegisterPage">
+    <Grid Background="#F0F0F0">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="40">
+                <TextBlock Text="Registrazione" FontSize="24" Margin="0,0,0,20"/>
+                <TextBlock Text="Ruolo"/>
+                <ComboBox x:Name="RoleComboBox" SelectedIndex="0">
+                    <ComboBoxItem Content="Studente"/>
+                    <ComboBoxItem Content="Docente"/>
+                </ComboBox>
+                <TextBlock Text="Username"/>
+                <TextBox x:Name="NicknameBox" Margin="0,0,0,10"/>
+                <TextBlock Text="Email"/>
+                <TextBox x:Name="EmailBox" Margin="0,0,0,10"/>
+                <TextBlock Text="Nome"/>
+                <TextBox x:Name="NameBox" Margin="0,0,0,10"/>
+                <TextBlock Text="Cognome"/>
+                <TextBox x:Name="SurnameBox" Margin="0,0,0,10"/>
+                <TextBlock Text="Data di nascita"/>
+                <DatePicker x:Name="BirthDatePicker" Margin="0,0,0,10"/>
+                <TextBlock Text="Genere"/>
+                <ComboBox x:Name="GenderComboBox" Margin="0,0,0,10">
+                    <ComboBoxItem Content="Uomo"/>
+                    <ComboBoxItem Content="Donna"/>
+                    <ComboBoxItem Content="Altro"/>
+                </ComboBox>
+                <TextBlock Text="Password"/>
+                <TextBox x:Name="PasswordBox" Margin="0,0,0,10" PasswordChar='*'/>
+                <TextBlock Text="Conferma Password"/>
+                <TextBox x:Name="ConfirmPasswordBox" Margin="0,0,0,20" PasswordChar='*'/>
+                <Button Content="Registrati" Click="RegisterUser_ClickAsync" Height="40"/>
+                <Button Content="Indietro" Click="BackToLogin_Click" Height="40" Margin="0,10,0,0"/>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/TestGeneratorClient/Views/RegisterPage.axaml.cs
+++ b/TestGeneratorClient/Views/RegisterPage.axaml.cs
@@ -1,0 +1,68 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using TestGeneratorClient.Services;
+using TestGeneratorClient.Utils;
+
+namespace TestGeneratorClient.Views;
+
+public partial class RegisterPage : UserControl
+{
+    private readonly MainWindow _mainWindow;
+    private readonly AuthService _authService = new();
+
+    public RegisterPage(MainWindow mainWindow)
+    {
+        InitializeComponent();
+        _mainWindow = mainWindow;
+    }
+
+    private async void RegisterUser_ClickAsync(object? sender, RoutedEventArgs e)
+    {
+        string ruolo = (RoleComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty;
+        string username = NicknameBox.Text ?? string.Empty;
+        string email = EmailBox.Text ?? string.Empty;
+        string nome = NameBox.Text ?? string.Empty;
+        string cognome = SurnameBox.Text ?? string.Empty;
+        string genere = (GenderComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty;
+        string password = PasswordBox.Text ?? string.Empty;
+        string confirmPassword = ConfirmPasswordBox.Text ?? string.Empty;
+        string data_nascita = BirthDatePicker.SelectedDate?.ToString("yyyy-MM-dd") ?? string.Empty;
+
+        if (password != confirmPassword)
+        {
+            await MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore", "Le password non coincidono.")
+                .ShowDialog(_mainWindow);
+            return;
+        }
+
+        try
+        {
+            var (success, message) = await _authService.RegisterAsync(ruolo, username, email, nome, cognome, genere, password, data_nascita);
+            if (success)
+            {
+                await MessageBox.Avalonia.MessageBoxManager
+                    .GetMessageBoxStandardWindow("Successo", message)
+                    .ShowDialog(_mainWindow);
+                _mainWindow.Navigate(new LoginPage(_mainWindow));
+            }
+            else
+            {
+                await MessageBox.Avalonia.MessageBoxManager
+                    .GetMessageBoxStandardWindow("Errore", message)
+                    .ShowDialog(_mainWindow);
+            }
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Exception", $"Errore durante la registrazione: {ex.Message}")
+                .ShowDialog(_mainWindow);
+        }
+    }
+
+    private void BackToLogin_Click(object? sender, RoutedEventArgs e)
+    {
+        _mainWindow.Navigate(new LoginPage(_mainWindow));
+    }
+}

--- a/TestGeneratorClient/Views/StudentStats.axaml
+++ b/TestGeneratorClient/Views/StudentStats.axaml
@@ -1,0 +1,55 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:oxy="clr-namespace:OxyPlot.Avalonia;assembly=OxyPlot.Avalonia"
+             x:Class="TestGeneratorClient.Views.StudentStats">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="150"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Background="#EFEFEF">
+            <Button Content="Informazioni" Margin="10" Click="InfoButton_Click"/>
+            <Button Content="Prestazioni" Margin="10" Click="PerformanceButton_Click"/>
+            <Button Content="Andamento" Margin="10" Click="TimelineButton_Click"/>
+        </StackPanel>
+        <Grid Grid.Column="1" Margin="10">
+            <Grid x:Name="InfoPanel" IsVisible="True">
+                <StackPanel>
+                    <TextBlock Text="Informazioni Studente" FontSize="20" FontWeight="Bold" Margin="0,0,0,10"/>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Nome:" Grid.Row="0" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5"/>
+                        <TextBlock x:Name="NameText" Grid.Row="0" Grid.Column="1"/>
+                        <TextBlock Text="Email:" Grid.Row="1" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5"/>
+                        <TextBlock x:Name="EmailText" Grid.Row="1" Grid.Column="1"/>
+                        <TextBlock Text="Data Nascita:" Grid.Row="2" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,5"/>
+                        <TextBlock x:Name="BirthDateText" Grid.Row="2" Grid.Column="1"/>
+                        <TextBlock Text="Genere:" Grid.Row="3" Grid.Column="0" FontWeight="Bold" Margin="0,0,10,0"/>
+                        <TextBlock x:Name="GenderText" Grid.Row="3" Grid.Column="1"/>
+                    </Grid>
+                </StackPanel>
+            </Grid>
+            <Grid x:Name="PerformancePanel" IsVisible="False">
+                <StackPanel>
+                    <TextBlock Text="Prestazioni per Categoria/Difficoltà" FontSize="20" FontWeight="Bold" Margin="0,0,0,10"/>
+                    <oxy:PlotView x:Name="PerformanceChart" Height="300" />
+                </StackPanel>
+            </Grid>
+            <Grid x:Name="TimelinePanel" IsVisible="False">
+                <StackPanel>
+                    <TextBlock Text="Andamento Temporale" FontSize="20" FontWeight="Bold" Margin="0,0,0,10"/>
+                    <oxy:PlotView x:Name="StudentTimelineChart" Height="300" />
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/TestGeneratorClient/Views/StudentStats.axaml.cs
+++ b/TestGeneratorClient/Views/StudentStats.axaml.cs
@@ -1,0 +1,130 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using OxyPlot;
+using OxyPlot.Series;
+using OxyPlot.Axes;
+using TestGeneratorClient.Services;
+using TestGeneratorClient.Models;
+
+namespace TestGeneratorClient.Views;
+
+public partial class StudentStats : UserControl
+{
+    private readonly AnalyticsService analyticsService;
+    private readonly string _jwtToken;
+    private StudentStatsResponse? _stats;
+    private readonly MainWindow _mainWindow;
+
+    public StudentStats(string jwtToken, MainWindow mainWindow)
+    {
+        InitializeComponent();
+        _jwtToken = jwtToken;
+        _mainWindow = mainWindow;
+        analyticsService = new AnalyticsService(_jwtToken);
+        LoadStudentStats();
+    }
+
+    private async void LoadStudentStats()
+    {
+        var result = await analyticsService.GetStudentStatsAsync();
+        if (result == null || !result.Success || result.Data == null)
+        {
+            await MessageBox.Avalonia.MessageBoxManager
+                .GetMessageBoxStandardWindow("Errore", "Errore nel caricamento delle statistiche dello studente: " + result?.ErrorMessage)
+                .ShowDialog(_mainWindow);
+            return;
+        }
+        _stats = result.Data;
+        var studente = _stats.Studente;
+        NameText.Text = $"{studente.Nome} {studente.Cognome}";
+        EmailText.Text = studente.Email;
+        BirthDateText.Text = studente.DataNascita.ToShortDateString();
+        GenderText.Text = studente.Genere;
+
+        var performanceModel = new PlotModel { Title = "Prestazioni per Categoria/Difficoltà" };
+        var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom };
+        var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0, AbsoluteMinimum = 0 };
+        performanceModel.Axes.Add(categoryAxis);
+        performanceModel.Axes.Add(valueAxis);
+
+        var correctSeriesCat = new ColumnSeries { Title = "Corrette" };
+        var wrongSeriesCat = new ColumnSeries { Title = "Sbagliate" };
+        var notAnsweredSeriesCat = new ColumnSeries { Title = "Non Date" };
+
+        foreach (var stat in _stats.StatsPerCategoriaDifficolta)
+        {
+            var label = $"{stat.Categoria} ({stat.Difficolta})";
+            categoryAxis.Labels.Add(label);
+            correctSeriesCat.Items.Add(new ColumnItem(stat.Corrette));
+            wrongSeriesCat.Items.Add(new ColumnItem(stat.Sbagliate));
+            notAnsweredSeriesCat.Items.Add(new ColumnItem(stat.NonDate));
+        }
+
+        performanceModel.Series.Add(correctSeriesCat);
+        performanceModel.Series.Add(wrongSeriesCat);
+        performanceModel.Series.Add(notAnsweredSeriesCat);
+        PerformanceChart.Model = performanceModel;
+
+        var timelineData = _stats.AndamentoTemporale;
+        var plotModel = new PlotModel { Title = "Andamento Temporale" };
+
+        var dateAxis = new DateTimeAxis
+        {
+            Position = AxisPosition.Bottom,
+            StringFormat = "dd/MM",
+            IntervalType = DateTimeIntervalType.Days,
+            MinorIntervalType = DateTimeIntervalType.Days,
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Dot
+        };
+
+        var valueAxisTime = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            MinimumPadding = 0,
+            AbsoluteMinimum = 0
+        };
+
+        plotModel.Axes.Add(dateAxis);
+        plotModel.Axes.Add(valueAxisTime);
+
+        var correctSeries = new LineSeries { Title = "Corrette", MarkerType = MarkerType.Circle };
+        var wrongSeries = new LineSeries { Title = "Sbagliate", MarkerType = MarkerType.Circle };
+        var notAnsweredSeries = new LineSeries { Title = "Non Date", MarkerType = MarkerType.Circle };
+
+        foreach (var record in timelineData)
+        {
+            var x = DateTimeAxis.ToDouble(record.Date);
+            correctSeries.Points.Add(new DataPoint(x, record.Corrette));
+            wrongSeries.Points.Add(new DataPoint(x, record.Sbagliate));
+            notAnsweredSeries.Points.Add(new DataPoint(x, record.NonDate));
+        }
+
+        plotModel.Series.Add(correctSeries);
+        plotModel.Series.Add(wrongSeries);
+        plotModel.Series.Add(notAnsweredSeries);
+
+        StudentTimelineChart.Model = plotModel;
+    }
+
+    private void InfoButton_Click(object? sender, RoutedEventArgs e)
+    {
+        InfoPanel.IsVisible = true;
+        PerformancePanel.IsVisible = false;
+        TimelinePanel.IsVisible = false;
+    }
+
+    private void PerformanceButton_Click(object? sender, RoutedEventArgs e)
+    {
+        InfoPanel.IsVisible = false;
+        PerformancePanel.IsVisible = true;
+        TimelinePanel.IsVisible = false;
+    }
+
+    private void TimelineButton_Click(object? sender, RoutedEventArgs e)
+    {
+        InfoPanel.IsVisible = false;
+        PerformancePanel.IsVisible = false;
+        TimelinePanel.IsVisible = true;
+    }
+}


### PR DESCRIPTION
## Summary
- migrate UI from WPF project to Avalonia
- add pages for login, registration, lobby, quiz creation and stats
- include service and util classes used by the UI
- update MainWindow to host Avalonia views
- add MessageBox.Avalonia package

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687baa490704832b8604ea61d9347246