### PR TITLE
Add detailed student statistics graphs

### DIFF
--- a/QuizClient/QuizClient/StudentStats.xaml
+++ b/QuizClient/QuizClient/StudentStats.xaml
@@ -53,8 +53,12 @@
             <!-- Prestazioni per categoria/difficolta -->
             <Grid x:Name="PerformancePanel" Visibility="Collapsed">
                 <StackPanel>
+                    <TextBlock Text="Quiz per Categoria" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
+                    <oxy:PlotView x:Name="CategoryChart" Height="250" Margin="0,0,0,20" />
                     <TextBlock Text="Prestazioni per Categoria/Difficoltà" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
-                    <oxy:PlotView x:Name="PerformanceChart" Height="300" />
+                    <oxy:PlotView x:Name="PerformanceChart" Height="250" Margin="0,0,0,20" />
+                    <TextBlock Text="Percentuale Corrette per Difficoltà" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" />
+                    <oxy:PlotView x:Name="DifficultyChart" Height="250" />
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
## Summary
- refine *StudentStats.xaml* layout
- show quiz counts by category, performance per category/difficulty and accuracy by difficulty
- compute chart data in code-behind using OxyPlot

## Testing
- `dotnet build QuizClient.csproj -c Release` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_e_687bc0feb41c832ba3cb8a41bb670da2