### PR TITLE
Clean up analytics service auth and remove unused imports

### DIFF
--- a/analytics_service/logic/stats_service.py
+++ b/analytics_service/logic/stats_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from models.ORM_models import Quiz, QuizQuesito, Quesito, CategoriaQuesito, Categoria, Utente

--- a/analytics_service/utils/auth.py
+++ b/analytics_service/utils/auth.py
@@ -1,6 +1,4 @@
 from jose import JWTError, jwt
-from datetime import datetime, timedelta, timezone
-from typing import Optional
 from fastapi import HTTPException, Header
 
 
@@ -23,17 +21,14 @@ def validate_token(authorization: str = Header(None)) -> dict:
     """
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Token non fornito o malformato")
-    
+
     # Estrae il token dall'header Authorization.
     # Se il token non inizia con "Bearer ", restituisce un errore 401.
     token = authorization.split("Bearer ")[1]
-    user_data = get_data_from_token(token)
-    if not user_data:
-        raise HTTPException(status_code=401, detail="Token non valido o scaduto")
-    return user_data
+    return get_data_from_token(token)
 
 
-def get_data_from_token(token: str) -> Optional[dict]:
+def get_data_from_token(token: str) -> dict:
     """
     Decodifica il token JWT e restituisce i dati utente.
 
@@ -51,5 +46,5 @@ def get_data_from_token(token: str) -> Optional[dict]:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         return payload
     except JWTError:
-        # Restituisce None se il token non è valido
-        return None
+        # Propaga un errore HTTP se il token non è valido o scaduto
+        raise HTTPException(status_code=401, detail="Token non valido o scaduto")


### PR DESCRIPTION
## Summary
- Simplify JWT token validation by raising HTTP errors directly
- Remove unused imports in analytics service logic

## Testing
- `pytest`
- `go test ./...` (CRUD_service)
- `go test ./...` (quiz_service)


------
https://chatgpt.com/codex/tasks/task_e_689b7777caf8832ba9b606ad04e1790f